### PR TITLE
Better handling of dispatch queue

### DIFF
--- a/src/queue-methods.js
+++ b/src/queue-methods.js
@@ -64,9 +64,11 @@ module.exports = {
                 if (!this._running) this._running = true;
                 let request = this.dequeue();
                 let method = request.method;
-                let callback = request.callback;
-                let response = await method(...request.parameters, request.options);
-                callback(response, ...request.callbackParameters);
+				let callback = request.callback;
+				let error = null;
+				let response = await method(...request.parameters, request.options)
+					.catch((e) => error = e);
+                callback(response, error, ...request.callbackParameters);
             }
             this._running = false;
         } catch(error) {

--- a/src/queue-methods.js
+++ b/src/queue-methods.js
@@ -66,7 +66,7 @@ module.exports = {
                 let method = request.method;
                 let callback = request.callback;
                 let response = await method(...request.parameters, request.options);
-                callback(response, ...request.callbackParamerters);
+                callback(response, ...request.callbackParameters);
             }
             this._running = false;
         } catch(error) {


### PR DESCRIPTION
Typo is obviously fatal. Second PR relates to error handling when a promise rejection occurs in the queue. The current behaviour is just to throw which ends up terminating the whole queue, which is a massive pain, especially for those of us who wish to handle the errors. Passed the error into the second parameter of the callback function, in line with other popular libraries such as request.