### PR TITLE
Queues broke w/out callbkParams if no "|| []"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-web-api",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "chess.com api wrapper",
   "main": "src/index.js",
   "scripts": {

--- a/src/queue/index.js
+++ b/src/queue/index.js
@@ -36,7 +36,7 @@ function dispatch(method, callback, parameters, options, callbackParameters, pri
     parameters: _parameters,
     options: _options,
     priority: _priority || 1,
-    callbackParameters: _callbackParameters,
+    callbackParameters: _callbackParameters || [],
   };
 
   this.enqueue(request);


### PR DESCRIPTION
Hi, so the previous build to September before you rewrote had `actualCallbackParameters || []` which meant that if undefined in the constructor, there was a default version.
This is really important because the queue method on line 98 uses the spread operator `...callbackParameters` which throws if the variable is undefined so there **must** be a defined value to callbackParameters.
Added || [] back in.