### PR TITLE
Fix both "User-Agent Contact Info Required" and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-web-api",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "chess.com api wrapper",
   "main": "src/index.js",
   "scripts": {

--- a/src/request/base-request.js
+++ b/src/request/base-request.js
@@ -10,6 +10,13 @@ const Request = function (builder) {
   this.bodyParameters = builder.bodyParameters;
   this.headers = builder.headers;
   this.path = builder.path;
+
+  if (this.headers === undefined) {
+    this.headers = {'User-Agent': 'chess-web-api/1.1.3'};
+  }
+  else if ((typeof this.headers === "object") && (!this.headers.hasOwnProperty('User-Agent'))) {
+    this.headers['User-Agent'] = 'chess-web-api/1.1.3';
+  }
 };
 
 Request.prototype._getter = function (key) {

--- a/src/request/base-request.js
+++ b/src/request/base-request.js
@@ -12,9 +12,8 @@ const Request = function (builder) {
   this.path = builder.path;
 
   if (this.headers === undefined) {
-    this.headers = {'User-Agent': 'chess-web-api/1.1.3'};
-  }
-  else if ((typeof this.headers === "object") && (!this.headers.hasOwnProperty('User-Agent'))) {
+    this.headers = { 'User-Agent': 'chess-web-api/1.1.3' };
+  } else if ((typeof this.headers === 'object') && !Object.prototype.hasOwnProperty.call(this.headers, 'User-Agent')) {
     this.headers['User-Agent'] = 'chess-web-api/1.1.3';
   }
 };

--- a/tests/clubs.test.js
+++ b/tests/clubs.test.js
@@ -27,10 +27,14 @@ describe('Endpoints: Clubs', () => {
 
     it('Missing ID', async () => {
       try {
-        expect.assertions(1);
-        await getClub();
+        expect.assertions(3);
+        const data = await getClub();
+
+        expect(data.statusCode).toEqual(200);
+        expect(data.body).toHaveProperty('name');
+        expect(data.body.name).toEqual('undefined');
       } catch (error) {
-        expect(error.statusCode).toEqual(404);
+        console.log(error);
       }
     });
   });
@@ -51,10 +55,14 @@ describe('Endpoints: Clubs', () => {
 
     it('Missing ID', async () => {
       try {
-        expect.assertions(1);
-        await getClubMembers();
+        expect.assertions(3);
+        const data = await getClubMembers();
+
+        expect(data.statusCode).toEqual(200);
+        expect(data.body).toHaveProperty('weekly');
+        expect(data.body.weekly).toEqual([]);
       } catch (error) {
-        expect(error.statusCode).toEqual(404);
+        console.log(error);
       }
     });
   });
@@ -77,10 +85,16 @@ describe('Endpoints: Clubs', () => {
 
     it('Missing ID', async () => {
       try {
-        expect.assertions(1);
-        await getClubMatches();
+        expect.assertions(5);
+        const data = await getClubMatches();
+
+        expect(data.statusCode).toEqual(200);
+        expect(data.body).toHaveProperty('finished');
+        expect(data.body).toHaveProperty('in_progress');
+        expect(data.body).toHaveProperty('registered');
+        expect(data.body.finished).toEqual([]);
       } catch (error) {
-        expect(error.statusCode).toEqual(404);
+        console.log(error);
       }
     });
   });

--- a/tests/queue.test.js
+++ b/tests/queue.test.js
@@ -49,7 +49,7 @@ describe('Functionality: Priority Queue', () => {
     it('Valid Call', async () => {
       try {
         expect.assertions(1);
-        const method = jest.fn();
+        const method = jest.fn(() => Promise.resolve());
         await queue.dispatch(method, () => (null), []);
         expect(method).toHaveBeenCalled();
       } catch (error) {
@@ -62,7 +62,7 @@ describe('Functionality: Priority Queue', () => {
     it('Valid Call', async () => {
       try {
         expect.assertions(1);
-        const method = jest.fn();
+        const method = jest.fn(() => Promise.resolve());
         await queue.dispatch(method, () => (null), ['1', '2']);
         expect(method).toHaveBeenLastCalledWith('1', '2', undefined);
       } catch (error) {


### PR DESCRIPTION
## Summary

Chess.com announced an API break last June (see Issue https://github.com/andyruwruw/chess-web-api/issues/35).

This PR proposes to solve it by setting the `User-Agent` in the `base-request`:
```
  if (this.headers === undefined) {
    this.headers = { 'User-Agent': 'chess-web-api/1.1.3' };
  } else if ((typeof this.headers === 'object') && !Object.prototype.hasOwnProperty.call(this.headers, 'User-Agent')) {
    this.headers['User-Agent'] = 'chess-web-api/1.1.3';
  }
```

## Other Information

While pushing, I've noticed some failing tests:

- `club.test.js`

The `Missing ID` tests were expecting the API to throw an error while the API still returns as usual but with empty fields

- `queue.test.js`

The `jest.fn()` was used to create a mock function for `method`.
This mock function, by default, returns `undefined`. So, when you trying to use `.catch()` on it, you get an error.

Now, the mock function return a resolved promise.